### PR TITLE
Updating onvm build instructions

### DIFF
--- a/README
+++ b/README
@@ -176,7 +176,6 @@ Also, no core overlap between applications and onvm_mgr is allowed.
 1. Install openNetVM using the following instructions 
            https://github.com/sdnfv/openNetVM/blob/master/docs/Install.md
 
-
 2. Set up the dpdk interfaces:
 	   # bash setup_mtcp_onvm_env.sh
 

--- a/README
+++ b/README
@@ -176,10 +176,14 @@ Also, no core overlap between applications and onvm_mgr is allowed.
 1. Install openNetVM using the following instructions 
            https://github.com/sdnfv/openNetVM/blob/master/docs/Install.md
 
-2. Next bring the dpdk-registered interfaces up. This can be setup using:
+
+2. Set up the dpdk interfaces:
+	   # bash setup_mtcp_onvm_env.sh
+
+3. Next bring the dpdk-registered interfaces up. This can be setup using:
 	   # sudo ifconfig dpdk0 x.x.x.x netmask 255.255.255.0 up
 
-3. Setup mtcp library
+4. Setup mtcp library
 	   # ./configure --with-dpdk-lib=$<path_to_dpdk> --with-onvm-lib=$<path_to_onvm_lib>
 	   # e.g. ./configure --with-dpdk-lib=$RTE_SDK/$RTE_TARGET --with-onvm-lib=`echo $ONVM_HOME`/onvm
 	   # make

--- a/README.md
+++ b/README.md
@@ -214,13 +214,19 @@ ONVM basics are explained in https://github.com/sdnfv/openNetVM.
 
 1. [Install openNetVM following these instructions](https://github.com/sdnfv/openNetVM/blob/master/docs/Install.md)
 
-2. Next bring the dpdk-registered interfaces up. This can be setup using:  
+2. Set up the dpdk interfaces:
+
+    ```bash
+	./setup_mtcp_onvm_env.sh
+    ```
+
+3. Next bring the dpdk-registered interfaces up. This can be setup using:  
 
     ```bash
     sudo ifconfig dpdk0 x.x.x.x netmask 255.255.255.0 up
     ```
 
-3. Setup mtcp library
+4. Setup mtcp library
     ```bash
     ./configure --with-dpdk-lib=$<path_to_dpdk> --with-onvm-lib=$<path_to_onvm_lib>
     # e.g. ./configure --with-dpdk-lib=$RTE_SDK/$RTE_TARGET --with-onvm-lib=`echo $ONVM_HOME`/onvm

--- a/setup_mtcp_onvm_env.sh
+++ b/setup_mtcp_onvm_env.sh
@@ -3,13 +3,13 @@
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-if [ -z "$RTE_TARGET" ]; then
-    echo "Please follow onvm install instructions to export \$RTE_TARGET"
+if [ -z "$RTE_SDK" ]; then
+    echo "Please follow onvm install instructions to export \$RTE_SDK"
     exit 1
 fi
 
-if [ -z "$RTE_SDK" ]; then
-    echo "Please follow onvm install instructions to export \$RTE_SDK"
+if [ -z "$RTE_TARGET" ]; then
+    echo "Please follow onvm install instructions to export \$RTE_TARGET"
     exit 1
 fi
 
@@ -17,11 +17,10 @@ fi
 cd $(dirname ${BASH_SOURCE[0]})/
 
 printf "${GREEN}Checking ldflags.txt...\n$NC"
-if grep "ldflags.txt" $RTE_SDK/mk/rte.app.mk > /dev/null
-then
-    :
-else
-    sed -i -e 's/O_TO_EXE_STR =/\$(shell if [ \! -d \${RTE_SDK}\/\${RTE_TARGET}\/lib ]\; then mkdir \${RTE_SDK}\/\${RTE_TARGET}\/lib\; fi)\nLINKER_FLAGS = \$(call linkerprefix,\$(LDLIBS))\n\$(shell echo \${LINKER_FLAGS} \> \${RTE_SDK}\/\${RTE_TARGET}\/lib\/ldflags\.txt)\nO_TO_EXE_STR =/g' $RTE_SDK/mk/rte.app.mk
+if [ ! -f $RTE_SDK/$RTE_TARGET/lib/ldflags.txt ]; then
+   echo "File $RTE_SDK/$RTE_TARGET/lib/ldflags.txt does not exist, please reinstall dpdk."
+   sed -i -e 's/O_TO_EXE_STR =/\$(shell if [ \! -d \${RTE_SDK}\/\${RTE_TARGET}\/lib ]\; then mkdir \${RTE_SDK}\/\${RTE_TARGET}\/lib\; fi)\nLINKER_FLAGS = \$(call linkerprefix,\$(LDLIBS))\n\$(shell echo \${LINKER_FLAGS} \> \${RTE_SDK}\/\${RTE_TARGET}\/lib\/ldflags\.txt)\nO_TO_EXE_STR =/g' $RTE_SDK/mk/rte.app.mk
+   exit 1
 fi
 
 printf "${GREEN}RTE_SDK$NC env variable is set to $RTE_SDK\n"

--- a/setup_mtcp_onvm_env.sh
+++ b/setup_mtcp_onvm_env.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+if [ -z "$RTE_TARGET" ]; then
+    echo "Please follow onvm install instructions to export \$RTE_TARGET"
+    exit 1
+fi
+
+if [ -z "$RTE_SDK" ]; then
+    echo "Please follow onvm install instructions to export \$RTE_SDK"
+    exit 1
+fi
+
+# Get to script directory
+cd $(dirname ${BASH_SOURCE[0]})/
+
+printf "${GREEN}Checking ldflags.txt...\n$NC"
+if grep "ldflags.txt" $RTE_SDK/mk/rte.app.mk > /dev/null
+then
+    :
+else
+    sed -i -e 's/O_TO_EXE_STR =/\$(shell if [ \! -d \${RTE_SDK}\/\${RTE_TARGET}\/lib ]\; then mkdir \${RTE_SDK}\/\${RTE_TARGET}\/lib\; fi)\nLINKER_FLAGS = \$(call linkerprefix,\$(LDLIBS))\n\$(shell echo \${LINKER_FLAGS} \> \${RTE_SDK}\/\${RTE_TARGET}\/lib\/ldflags\.txt)\nO_TO_EXE_STR =/g' $RTE_SDK/mk/rte.app.mk
+fi
+
+printf "${GREEN}RTE_SDK$NC env variable is set to $RTE_SDK\n"
+printf "${GREEN}RTE_TARGET$NC env variable is set to $RTE_TARGET\n"
+
+# Check if you are using an Intel NIC
+while true; do
+    read -p "Are you using an Intel NIC (y/n)? " response
+    case $response in
+	[Yy]* ) break;;
+	[Nn]* ) exit;;
+    esac
+done
+
+# Create interfaces
+printf "Creating ${GREEN}dpdk$NC interface entries\n"
+cd dpdk-iface-kmod
+make
+if lsmod | grep dpdk_iface &> /dev/null ; then
+    :
+else    
+    sudo insmod ./dpdk_iface.ko
+fi
+sudo -E make run
+cd ..


### PR DESCRIPTION
This pr updates the openNetVM module install instructions for mTCP

The `./setup_mtcp_dpdk.env` script adds necessary steps for creating `ldflags.txt`, we added those steps to both the openNetVM install script and the `setup_mtcp_onvm_env.sh` script. Added appropriate changes to the READMEs.