### PR TITLE
Fixed mtcp doesn't notify onvm to reclaim resource when a mtcp based …

### DIFF
--- a/mtcp/src/core.c
+++ b/mtcp/src/core.c
@@ -1638,6 +1638,11 @@ mtcp_destroy()
 #ifndef DISABLE_DPDK
 	mpz_clear(CONFIG._cpumask);
 #endif
+
+#ifdef ENABLE_ONVM
+	onvm_nflib_stop(CONFIG.nf_info);
+#endif
+
 	TRACE_INFO("All MTCP threads are joined.\n");
 }
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
Fix bug: When a mtcp-based NF exits normally, it doesn't call onvm api to let onvm reclaim resource. This change has been tested and confirmed by @koolzz 