### PR TITLE
Fix OpenNetVM README example args

### DIFF
--- a/README
+++ b/README
@@ -264,10 +264,10 @@ to a error(s) resembling the one mentioned below:
     OR
   # EAL: Cannot mmap device resource file /sys/bus/pci/devices/0000:06:00.0/resource3 to address: 0x7ffff7ff1000 
 
-To prevent this, use the base virtual address parameter to run the ONVM manager, e.g.:
+To prevent this, use the base virtual address parameter to run the ONVM manager(core list arg `0xf8` isn't actually used by mtcp NFs but is required), e.g.:
 
 cd openNetVM/onvm
-./go.sh 1,2,3 1 -s stdout -a 0x7f000000000
+./go.sh 1,2,3 1 0xf8 -s stdout -a 0x7f000000000
 
 
 - NETMAP VERSION -

--- a/README.md
+++ b/README.md
@@ -321,11 +321,11 @@ to an error resembling the one mentioned below:
 - ``` Cannot mmap memory for rte_config at [0x7ffff7fb6000], got [0x7ffff7e74000] - please use '--base-virtaddr' option```
 - ```EAL: Cannot mmap device resource file /sys/bus/pci/devices/0000:06:00.0/resource3 to address: 0x7ffff7ff1000```
 
-To prevent this, use the base virtual address parameter to run the ONVM manager, e.g.:
+To prevent this, use the base virtual address parameter to run the ONVM manager (core list arg `0xf8` isn't actually used by mtcp NFs but is required), e.g.:
 
 ```bash
 cd openNetVM/onvm  
-./go.sh 1,2,3 1 -s stdout -a 0x7f000000000 
+./go.sh 1,2,3 1 0xf8 -s stdout -a 0x7f000000000 
 ```
 
 ### ***NETMAP VERSION***


### PR DESCRIPTION
Fix outdated cmds in READMEs

**Summary:**
The example args to run `onvm_mgr` provided in the READMEs were outdated. The ONVM manager now does its own core handling for NFs and required the NF coremask argument, as mtcp does its own core managing independent of the onvm_mgr that argument isn't actually used, **but** it is required so that mtcp NFs properly start.