### PR TITLE
Fix lighttpd configure script for ONVM

### DIFF
--- a/apps/lighttpd-1.4.32/configure.ac
+++ b/apps/lighttpd-1.4.32/configure.ac
@@ -711,10 +711,8 @@ LIBONVM_CFLAGS=""
 LIBONVM_LIBS=""
 
 if test "$WITH_LIBONVM" != "no"; then
-	LIBONVM_CFLAGS="-I$WITH_LIBONVM/onvm_nflib"
-	LIBONVM_CFLAGS="-I$WITH_LIBONVM/lib"
-	LIBONVM_LIBS="$WITH_LIBONVM/onvm_nflib/$RTE_TARGET/libonvm.a"
-	LIBONVM_LIBS="$WITH_LIBONVM/lib/$RTE_TARGET/lib/libonvmhelper.a -lm"
+	LIBONVM_CFLAGS="-I$WITH_LIBONVM/onvm_nflib -I$WITH_LIBONVM/lib"
+	LIBONVM_LIBS="$WITH_LIBONVM/onvm_nflib/$RTE_TARGET/libonvm.a $WITH_LIBONVM/lib/$RTE_TARGET/lib/libonvmhelper.a -lm"
 	CFLAGS="${CFLAGS} ${LIBONVM_CFLAGS}"
 	AC_DEFINE([HAVE_LIBONVM], [1], [libonvm support])
 	AC_MSG_RESULT(yes)


### PR DESCRIPTION
Before the script was doing something strange and lighttpd woudn't properly build. This pr fixes the configure.ac script so that lighttpd properly compiles.

@eunyoung14 can you tell me If I'm missing any files for the commit, I'm unfamiliar with the autoreconf system. I've executed the `autoreconf -ivf` command to fix the linking but I'm not sure if I need to add any files besides the `configure.ac`.