### PR TITLE
replace constants with macros for clarity

### DIFF
--- a/mtcp/src/ccp.c
+++ b/mtcp/src/ccp.c
@@ -36,12 +36,12 @@ _dp_set_cwnd(struct ccp_datapath *dp, struct ccp_connection *conn, uint32_t cwnd
 	// (time_ms) (rtt) (curr_cwnd_pkts) (new_cwnd_pkts) (ssthresh)
 	if (cwnd != stream->sndvar->cwnd) {
 		CCP_PROBE("%lu %d %d->%d (ss=%d)\n", 
-			  now_usecs() / 1000, 
-			  stream->rcvvar->srtt * 125,
-			  stream->sndvar->cwnd / stream->sndvar->mss,
-			  new_cwnd / stream->sndvar->mss,
-			  stream->sndvar->ssthresh / stream->sndvar->mss
-			  );
+            USECS_TO_MS(now_usecs()),
+            UNSHIFT_SRTT(stream->rcvvar->srtt)
+            stream->sndvar->cwnd / stream->sndvar->mss,
+            new_cwnd / stream->sndvar->mss,
+            stream->sndvar->ssthresh / stream->sndvar->mss
+        );
 	}
 	stream->sndvar->cwnd = new_cwnd;
 }
@@ -223,13 +223,13 @@ ccp_cong_control(mtcp_manager_t mtcp, tcp_stream *stream,
 	mmt->bytes_acked       = bytes_delivered;
 	mmt->packets_acked     = packets_delivered;
 	mmt->snd_cwnd          = stream->sndvar->cwnd; 
-	mmt->rtt_sample_us     = stream->rcvvar->srtt * 125; 
+	mmt->rtt_sample_us     = UNSHIFT_SRTT(stream->rcvvar->srtt); 
 	mmt->bytes_in_flight   = 0; // TODO
 	mmt->packets_in_flight = 0; // TODO
 	mmt->rate_outgoing     = rin;
 	mmt->rate_incoming     = rout;
 #if TCP_OPT_SACK_ENABLED
-	mmt->bytes_misordered   = stream->rcvvar->sacked_pkts * 1448;
+	mmt->bytes_misordered   = stream->rcvvar->sacked_pkts * MSS;
 	mmt->packets_misordered = stream->rcvvar->sacked_pkts;
 #endif
 

--- a/mtcp/src/include/pacing.h
+++ b/mtcp/src/include/pacing.h
@@ -4,9 +4,6 @@
 #include "tcp_stream.h"
 #include "clock.h"
 
-#define MAX(a, b) ((a)>(b)?(a):(b))
-#define MIN(a, b) ((a)<(b)?(a):(b))
-
 #if RATE_LIMIT_ENABLED
 typedef struct token_bucket {
     double tokens;

--- a/mtcp/src/include/tcp_util.h
+++ b/mtcp/src/include/tcp_util.h
@@ -4,6 +4,18 @@
 #include "mtcp.h"
 #include "tcp_stream.h"
 
+#define MSS 1448
+#define INIT_CWND_PKTS 10
+
+#define MAX(a, b) ((a)>(b)?(a):(b))
+#define MIN(a, b) ((a)<(b)?(a):(b))
+
+#define SECONDS_TO_USECS(seconds) ((seconds) / 1000000.0)
+#define USECS_TO_MS(us) ((us) / 1000)
+#define BYTES_TO_BITS(bytes) ((bytes) / 8.0)
+#define BPS_TO_MBPS(bps) ((bps) / 8000000.0)
+#define UNSHIFT_RTT(srtt) ((srtt) * 125.0)
+
 struct tcp_timestamp
 {
 	uint32_t ts_val;

--- a/mtcp/src/pacing.c
+++ b/mtcp/src/pacing.c
@@ -1,5 +1,6 @@
 #include "pacing.h"
 #include "clock.h"
+#include "tcp_util.h"
 /*----------------------------------------------------------------------------*/
 #if RATE_LIMIT_ENABLED
 token_bucket *
@@ -11,7 +12,7 @@ NewTokenBucket()
 		return NULL;
 
 	bucket->rate = 0;
-	bucket->burst = 14480;
+	bucket->burst = (MSS * INIT_CWND_PKTS);
 	bucket->tokens = bucket->burst;
 	bucket->last_fill_t = now_usecs();
 	return bucket;
@@ -21,7 +22,7 @@ void
 _refill_bucket(token_bucket *bucket)
 {
 	uint32_t elapsed = time_since_usecs(bucket->last_fill_t);
-	double new_tokens = (bucket->rate / 1000000.0) * elapsed;
+	double new_tokens = SECONDS_TO_USECS(bucket->rate * elapsed);
 	double prev_tokens = bucket->tokens;
 	bucket->tokens = MIN(bucket->burst, bucket->tokens + new_tokens);
 	if (bucket->tokens > prev_tokens) {
@@ -34,7 +35,7 @@ _refill_bucket(token_bucket *bucket)
 int
 SufficientTokens(token_bucket *bucket, uint64_t new_bits)
 {
-	double new_bytes = (new_bits / 8.0);
+	double new_bytes = BITS_TO_BYTES(new_bits);
 
 	//fprintf(stderr, "checking for %ld tokens\n", new_bits);
 
@@ -52,7 +53,7 @@ void
 PrintBucket(token_bucket *bucket)
 {
 	fprintf(stderr, "[rate=%.3f tokens=%f last=%u]\n",
-		bucket->rate / 1000000.0,
+		BPS_TO_MBPS(bucket->rate),
 		bucket->tokens,
 		bucket->last_fill_t);
 }
@@ -74,7 +75,6 @@ NewPacketPacer()
 	return pacer;
 }
 /*----------------------------------------------------------------------------*/
-#define PACKET_SIZE 1500
 int
 CanSendNow(packet_pacer *pacer)
 {
@@ -84,7 +84,7 @@ CanSendNow(packet_pacer *pacer)
 
 	uint32_t now = now_usecs();
 	if (now >= pacer->next_send_time) {
-		pacer->next_send_time = now + (int)(PACKET_SIZE / (pacer->rate_bps / 8000000.0));
+		pacer->next_send_time = now + (int)(MSS / BPS_TO_MBPS(pacer->rate_bps));
 		pacer->extra_packets = 1;
 		//fprintf(stderr, "now=%u, next=%u\n", now, pacer->next_send_time);
 


### PR DESCRIPTION
I wasn't quite sure where to put these because they're needed in ccp.c, pacing.c and tcp_out.c. For now tcp_util.h made the most sense to me, but you may want to move it elsewhere if it doesn't match your structure well.