### PR TITLE
dpdk-iface-kmod: remove warning of ‘rte_eth_dev_count’ is deprecated.

### DIFF
--- a/dpdk-iface-kmod/dpdk_iface_main.c
+++ b/dpdk-iface-kmod/dpdk_iface_main.c
@@ -260,7 +260,11 @@ main(int argc, char **argv)
 	ret = rte_eal_init(rte_argc, rte_argv);
 
 	/* get total count of detected ethernet ports */
+#if RTE_VERSION < RTE_VERSION_NUM(18, 5, 0, 0)
 	num_devices = rte_eth_dev_count();
+#else
+	num_devices = rte_eth_dev_count_avail();
+#endif
 	if (num_devices == 0) {
 		fprintf(stderr, "No Ethernet port detected!\n");
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
rte_eth_dev_count is deprecated and use rte_eth_dev_count_avail instead.

Signed-off-by: Qingmin Liu <qingmin.liu@broadcom.com>