### PR TITLE
Add num_tx/num_rx config option to specify the DPDK driver TX/RX ring size

### DIFF
--- a/apps/apache_benchmark/README-mtcp
+++ b/apps/apache_benchmark/README-mtcp
@@ -16,18 +16,29 @@ If you want to use ab with mTCP,
   run configure with "--with-libmtcp" option.
 
 -FOR DPDK VERSION-
- $ ./configure --with-libmtcp=${PATH_TO_LIBMTCP} \
-    --with-libdpdk=${PATH_TO_LIBDPDK}
+
+ Compile apr for ab
+
+ $ cd <$PATH_TO_MTCP_RELEASE_V3>/apps/apache_benchmark/srclib/apr"
+ $ ./configure --with-libmtcp="<$PATH_TO_MTCP_RELEASE_V3>/mtcp" \
+    --with-libdpdk="$RTE_SDK/$RTE_TARGET"; make
+
+ $ cd <$PATH_TO_MTCP_RELEASE_V3>/apps/apache_benchmark/srclib/apr-util"
+ $ ./configure --with-apr="../apr"; make
+
+ Compile ab with apr, apr-util, libmtcp, libdpdk
+
+ $ cd <$PATH_TO_MTCP_RELEASE_V3>/apps/apache_benchmark
+ $ ./configure CFLAGS="-g -O3" \
+   --with-libmtcp="<$PATH_TO_MTCP_RELEASE_V3>/mtcp" \
+   --with-libdpdk="$RTE_SDK/$RTE_TARGET" \
+   --with-apr="./srclib/apr" \
+   --with-apr-util="./srclib/apr-util"
+ $ make
 
 -FOR PSIO VERSION-
  $ ./configure --with-libmtcp=${PATH_TO_LIBMTCP} \
     --with-libpsio=${PATH_TO_LIBPSIO}
-
-  (e.g.
-	$ ./configure CFLAGS="-g -O3" \
-	--with-libmtcp="<$PATH_TO_MTCP_RELEASE_V3>/mtcp/" \
-	--with-libdpdk="<$PATH_TO_MTCP_RELEASE_V3>/$RTE_SDK/$RTE_TARGET"
-  )
 
 -FOR NETMAP VERSION-
  $ ./configure --with-libmtcp=${PATH_TO_LIBMTCP}

--- a/apps/example/epserver.conf
+++ b/apps/example/epserver.conf
@@ -19,6 +19,15 @@ io = dpdk
 # Core mask
 #core_mask = 0000000F0
 
+# number of TX descriptor ring size, the default is 128
+
+# e.g. in case of VMXNET3 PMD, the min TX ring size is 512
+# this allows mTCP app runs on VMware ESXi VM
+# num_tx = 512
+
+# number of RX descriptor ring size, the default is 128
+# num_rx = 128
+
 # Number of memory channels per processor socket (dpdk-only)
 num_mem_ch = 4
 

--- a/apps/example/epwget.conf
+++ b/apps/example/epwget.conf
@@ -16,6 +16,15 @@ io = dpdk
 # following line is uncommented.
 #num_cores = 8
 
+# number of TX descriptor ring size, the default is 128
+
+# e.g. in case of VMXNET3 PMD, the min TX ring size is 512
+# this allows mTCP app runs on VMware ESXi VM
+# num_tx = 512
+
+# number of RX descriptor ring size, the default is 128
+# num_rx = 128
+
 # Number of memory channels per processor socket (dpdk-only)
 num_mem_ch = 4
 

--- a/config/sample_mtcp.conf
+++ b/config/sample_mtcp.conf
@@ -16,6 +16,15 @@ io = dpdk
 # following line is uncommented.
 #num_cores = 8
 
+# number of TX descriptor ring size, the default is 128
+
+# e.g. in case of VMXNET3 PMD, the min TX ring size is 512
+# this allows mTCP app runs on VMware ESXi VM
+# num_tx = 512
+
+# number of RX descriptor ring size, the default is 128
+# num_rx = 128
+
 # Enable multi-process support
 #multiprocess = 1
 

--- a/mtcp/src/config.c
+++ b/mtcp/src/config.c
@@ -591,6 +591,18 @@ ParseConfiguration(char *line)
 #ifndef DISABLE_DPDK
 		mpz_set_str(CONFIG._cpumask, q, 16);
 #endif
+	} else if (strcmp(p, "num_tx") == 0) {
+		CONFIG.num_tx = atoi(q);
+		if (CONFIG.num_tx < 0) {
+			TRACE_CONFIG("Number of TX ring descriptor should be larger than 0.\n");
+			return -1;
+		}
+	} else if (strcmp(p, "num_rx") == 0) {
+		CONFIG.num_rx = atoi(q);
+		if (CONFIG.num_rx < 0) {
+			TRACE_CONFIG("Number of RX ring descriptor should be larger than 0.\n");
+			return -1;
+		}
 	} else if (strcmp(p, "max_concurrency") == 0) {
 		CONFIG.max_concurrency = mystrtol(q, 10);
 		if (CONFIG.max_concurrency < 0) {
@@ -740,6 +752,8 @@ PrintConfiguration()
 	TRACE_CONFIG("Configurations:\n");
 	TRACE_CONFIG("Number of CPU cores available: %d\n", num_cpus);
 	TRACE_CONFIG("Number of CPU cores to use: %d\n", CONFIG.num_cores);
+	TRACE_CONFIG("Number of TX ring descriptor: %d\n", CONFIG.num_tx);
+	TRACE_CONFIG("Number of RX ring descriptor: %d\n", CONFIG.num_rx);
 	TRACE_CONFIG("Maximum number of concurrency per core: %d\n", 
 			CONFIG.max_concurrency);
 	if (CONFIG.multi_process == 1) {

--- a/mtcp/src/core.c
+++ b/mtcp/src/core.c
@@ -1521,6 +1521,8 @@ mtcp_getconf(struct mtcp_conf *conf)
 		return -1;
 
 	conf->num_cores = CONFIG.num_cores;
+	conf->num_tx = CONFIG.num_tx;
+	conf->num_rx = CONFIG.num_rx;
 	conf->max_concurrency = CONFIG.max_concurrency;
 
 	conf->max_num_buffers = CONFIG.max_num_buffers;
@@ -1541,6 +1543,10 @@ mtcp_setconf(const struct mtcp_conf *conf)
 
 	if (conf->num_cores > 0)
 		CONFIG.num_cores = conf->num_cores;
+	if (conf->num_tx > 0)
+		CONFIG.num_tx = conf->num_tx;
+	if (conf->num_rx > 0)
+		CONFIG.num_rx = conf->num_rx;
 	if (conf->max_concurrency > 0)
 		CONFIG.max_concurrency = conf->max_concurrency;
 	if (conf->max_num_buffers > 0)

--- a/mtcp/src/dpdk_module.c
+++ b/mtcp/src/dpdk_module.c
@@ -93,8 +93,8 @@
 #define ETHER_OVR			(RTE_ETHER_CRC_LEN + ETHER_PREAMBLE + ETHER_IFG)
 #endif
 
-static const uint16_t nb_rxd = 		RTE_TEST_RX_DESC_DEFAULT;
-static const uint16_t nb_txd = 		RTE_TEST_TX_DESC_DEFAULT;
+static uint16_t nb_rxd = 		RTE_TEST_RX_DESC_DEFAULT;
+static uint16_t nb_txd = 		RTE_TEST_TX_DESC_DEFAULT;
 /*----------------------------------------------------------------------------*/
 /* packet memory pools for storing packet bufs */
 static struct rte_mempool *pktmbuf_pool[MAX_CPUS] = {NULL};
@@ -696,6 +696,10 @@ dpdk_load_module(void)
 		}
 
 		/* Initialise each port */
+		if (CONFIG.num_tx)
+			nb_txd = CONFIG.num_tx;
+		if (CONFIG.num_rx)
+			nb_rxd = CONFIG.num_rx;
 		int i;
 		for (i = 0; i < num_devices_attached; ++i) {
 		        /* get portid form the index of attached devices */

--- a/mtcp/src/include/mtcp.h
+++ b/mtcp/src/include/mtcp.h
@@ -164,6 +164,8 @@ struct mtcp_config
 	struct arp_table arp;
 
 	int num_cores;
+	int num_tx;
+	int num_rx;
 	int num_mem_ch;
 	int max_concurrency;
 #ifndef DISABLE_DPDK

--- a/mtcp/src/include/mtcp_api.h
+++ b/mtcp/src/include/mtcp_api.h
@@ -30,6 +30,8 @@ enum socket_type
 struct mtcp_conf
 {
 	int num_cores;
+	int num_tx;
+	int num_rx;
 	int max_concurrency;
 
 	int max_num_buffers;


### PR DESCRIPTION

In dpdk_module.c,TX/RX ring size is hard coded to 128, this prevent mTCP example
apps from running in VMware ESXi VM since VMXNET3 PMD default TX descriptor ring size
minimum value is 512. With this new config option, mTCP example app users can specify
the DPDK TX/RX descriptor ring size to fit in users environment.