### PR TITLE
Support fcntl to make porting easier

### DIFF
--- a/mtcp/src/include/mtcp_api.h
+++ b/mtcp/src/include/mtcp_api.h
@@ -78,6 +78,8 @@ mtcp_getsockopt(mctx_t mctx, int sockid, int level,
 int 
 mtcp_setsockopt(mctx_t mctx, int sockid, int level, 
 		int optname, const void *optval, socklen_t optlen);
+int 
+mtcp_fcntl(mctx_t mctx, int sockid, int  operation, int flags_);
 
 int 
 mtcp_setsock_nonblock(mctx_t mctx, int sockid);


### PR DESCRIPTION
fcntl can be used to set a socket for non blocking and blocking as appropriate.

There is a set non blocking call but not blocking , but it would be nicer if there was support for fcntl to support non blocking/blocking in the traditional sense