### PR TITLE
Accept the packet with seq smaller than the last received packet

### DIFF
--- a/mtcp/src/tcp_ring_buffer.c
+++ b/mtcp/src/tcp_ring_buffer.c
@@ -294,6 +294,12 @@ RBPut(rb_manager_t rbm, struct tcp_ring_buffer* buff,
 	struct fragment_ctx* prev, *pprev;
 	int merged = 0;
 
+	if (cur_seq < buff->head_seq) {
+		len -= buff->head_seq - cur_seq;
+		data += buff->head_seq - cur_seq;
+		cur_seq = buff->head_seq;
+	}
+
 	if (len <= 0)
 		return 0;
 


### PR DESCRIPTION
This patch fix the following situation

```
+0 < . 1:1001(1000) ack 1 win 60395
+0.1 read(4, ..., 1000) =  1000
+0 < . 501:1501(1000) ack 1 win 14648
+0.5 read(4, ..., 500) =  500
```